### PR TITLE
[1.x] Introduce chore `Exceptions` for handling errors

### DIFF
--- a/src/Exceptions/FactoryException.php
+++ b/src/Exceptions/FactoryException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\Workbook\Exceptions;
+
+use RuntimeException;
+
+final class FactoryException extends RuntimeException implements WorkbookException
+{
+    /**
+     * Create a new instance when the field is invalid.
+     *
+     *      FactoryException::invalidField('batch', 'row_start|row_end', 'integers');
+     *      FactoryException::invalidField('row', 'index', 'integer');
+     *      FactoryException::invalidField('sheet', 'name', 'string');
+     */
+    public static function invalidField(string $entity, string $field, string $expected): self
+    {
+        $fields = array_map('trim', explode('|', $field));
+        $fields = array_map(fn ($item): string => "\"{$item}\"", $fields);
+
+        $length = count($fields);
+        $prefix = $length > 1 ? 'valid' : 'a valid';
+
+        $field = match ($length) {
+            1 => $fields[0],
+            2 => implode(' and ', $fields),
+            default => (static function (array $items): string {
+                /** @var string $last */
+                $last = array_pop($items);
+                $rest = implode(', ', $items);
+
+                return "{$rest}, and {$last}";
+            })($fields),
+        };
+
+        return new self("The {$entity} must have {$prefix} {$field} of type \"{$expected}\".");
+    }
+}

--- a/src/Exceptions/IOException.php
+++ b/src/Exceptions/IOException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\Workbook\Exceptions;
+
+use RuntimeException;
+
+final class IOException extends RuntimeException implements WorkbookException {}

--- a/src/Exceptions/IteratorException.php
+++ b/src/Exceptions/IteratorException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\Workbook\Exceptions;
+
+use RuntimeException;
+
+final class IteratorException extends RuntimeException implements WorkbookException
+{
+    /**
+     * Create a new instance when the current item is not available.
+     */
+    public static function noCurrentItem(): self
+    {
+        return new self('The current item is not available.');
+    }
+}

--- a/src/Exceptions/WorkbookException.php
+++ b/src/Exceptions/WorkbookException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\Workbook\Exceptions;
+
+use Throwable;
+
+interface WorkbookException extends Throwable {}

--- a/tests/Exceptions/FactoryExceptionTest.php
+++ b/tests/Exceptions/FactoryExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Exceptions;
+
+use Flockyn\Workbook\Exceptions\FactoryException;
+use Flockyn\Workbook\Exceptions\WorkbookException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class FactoryExceptionTest extends TestCase
+{
+    public static function dataProviderInvalidField(): array
+    {
+        return [
+            'single field' => [
+                'row',
+                'index',
+                'integer',
+                'The row must have a valid "index" of type "integer".',
+            ],
+            'two fields' => [
+                'batch',
+                'row_start|row_end',
+                'integers',
+                'The batch must have valid "row_start" and "row_end" of type "integers".',
+            ],
+            'multiple fields' => [
+                'sheet',
+                'name|title|label',
+                'string',
+                'The sheet must have valid "name", "title", and "label" of type "string".',
+            ],
+        ];
+    }
+
+    #[Test, DataProvider('dataProviderInvalidField')]
+    public function it_invalid_field(string $entity, string $field, string $expected, string $message): void
+    {
+        $e = FactoryException::invalidField($entity, $field, $expected);
+
+        $this->assertInstanceOf(FactoryException::class, $e);
+        $this->assertInstanceOf(WorkbookException::class, $e);
+
+        $this->assertSame($message, $e->getMessage());
+    }
+}

--- a/tests/Exceptions/IteratorExceptionTest.php
+++ b/tests/Exceptions/IteratorExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Exceptions;
+
+use Flockyn\Workbook\Exceptions\IteratorException;
+use Flockyn\Workbook\Exceptions\WorkbookException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class IteratorExceptionTest extends TestCase
+{
+    #[Test]
+    public function it_no_current_item(): void
+    {
+        $e = IteratorException::noCurrentItem();
+
+        $this->assertInstanceOf(IteratorException::class, $e);
+        $this->assertInstanceOf(WorkbookException::class, $e);
+
+        $this->assertSame('The current item is not available.', $e->getMessage());
+    }
+}


### PR DESCRIPTION
This pull request adds a chore of `Exceptions` for handling errors, including:
- `WorkbookException` -> Base exception for this package
- `IOException` - > For handling `I/O` related errors
- `FactoryException` -> To handle related error in `Factories` dirs
- `IteratorException` -> To handle related error in `Iterators` dirs